### PR TITLE
composer.json file added

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,0 +1,9 @@
+{
+    "name": "drupal/tmgmt_aac",
+    "description": "AAC Global plugin for TMGMT",
+    "type": "drupal-module",
+    "license": "GPL-2.0+",
+    "require": {
+        "drupal/tmgmt": "~1.0"
+    }
+}


### PR DESCRIPTION
This change adds composer.json which allows adding module to projects with composer by adding this section in project's composer.json file:
```
"repositories": [
    {
        "name": "drupal/tmgmt_aac",
        "type": "vcs",
        "url": "https://github.com/wunderio/tmgmt_aac.git"
    }
]
```
and then running `composer require drupal/tmgmt_aac`